### PR TITLE
Metatag Issue #110 alternative: Return element without using #attached.

### DIFF
--- a/src/SchemaNameBase.php
+++ b/src/SchemaNameBase.php
@@ -131,7 +131,6 @@ class SchemaNameBase extends BackdropTextMetaTag implements SchemaMetatagTestTag
       $this->processItem($value);
     }
     $parts = explode('.', $this->info['name']);
-    $id = 'schema_metatag_' . $this->info['name'];
     $element = [
       '#type' => 'head_tag',
       '#tag' => 'meta',
@@ -142,9 +141,7 @@ class SchemaNameBase extends BackdropTextMetaTag implements SchemaMetatagTestTag
         'content' => static::outputValue($value),
       ],
     ];
-    return array(
-      '#attached' => array('backdrop_add_html_head' => array(array($element, $id))),
-    );
+    return $element;
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/metatag/issues/110.

An alternative approach to have schema_metatag return an element that uses the current Backdrop Metatag module approach to adding data. More information in that issue. I am reusing the Metatag issue to keep the conversation in one place rather than starting an additional thread in the schema_metatag queue.